### PR TITLE
(feat): allow config values to be changed with hook 'surge/config'

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -19,7 +19,7 @@ const CACHE_DIR = WP_CONTENT_DIR . '/cache/surge';
  * @return mixed The config value for the supplied key.
  */
 function config( $key ) {
-	return [
+	return \apply_filters('surge/config', [
 		'ttl' => 600,
 		'ignore_cookies' => [ 'wordpress_test_cookie' ],
 
@@ -39,7 +39,7 @@ function config( $key ) {
 			'hsa_src', 'hsa_ad', 'hsa_acc', 'hsa_net', 'hsa_kw', 'hsa_tgt',
 			'hsa_ver', '_branch_match_id',
 		],
-	][ $key ];
+	])[ $key ];
 }
 
 /**


### PR DESCRIPTION
The values in the config array are hardcoded. Sometimes, it could be useful to change the values.

The hook `surge/config` (but name can be changed if required), allows values to be changed.