### PR TITLE
Invalidation enhancements

### DIFF
--- a/include/cache.php
+++ b/include/cache.php
@@ -62,7 +62,7 @@ $ob_callback = function( $contents ) {
 		'headers' => $headers,
 		'created' => time(),
 		'expires' => time() + config( 'ttl' ),
-		'flags' => flag(),
+		'flags' => array_unique( flag() ),
 		'path' => $key['path'],
 	];
 

--- a/include/invalidate.php
+++ b/include/invalidate.php
@@ -107,6 +107,10 @@ add_action( 'shutdown', function() {
 		'update_option_WPLANG',
 		'update_option_blogname',
 		'update_option_blogdescription',
+		'update_option_blog_public',
+		'update_option_show_on_front',
+		'update_option_page_on_front',
+		'update_option_page_for_posts',
 		'automatic_updates_complete',
 		'_core_updated_successfully',
 	];

--- a/include/invalidate.php
+++ b/include/invalidate.php
@@ -111,6 +111,7 @@ add_action( 'shutdown', function() {
 		'update_option_show_on_front',
 		'update_option_page_on_front',
 		'update_option_page_for_posts',
+		'update_option_woocommerce_permalinks',
 		'automatic_updates_complete',
 		'_core_updated_successfully',
 	];

--- a/include/invalidate.php
+++ b/include/invalidate.php
@@ -104,6 +104,7 @@ add_action( 'shutdown', function() {
 		'update_option_permalink_structure',
 		'update_option_tag_base',
 		'update_option_category_base',
+		'update_option_WPLANG',
 		'automatic_updates_complete',
 		'_core_updated_successfully',
 	];

--- a/include/invalidate.php
+++ b/include/invalidate.php
@@ -105,6 +105,8 @@ add_action( 'shutdown', function() {
 		'update_option_tag_base',
 		'update_option_category_base',
 		'update_option_WPLANG',
+		'update_option_blogname',
+		'update_option_blogdescription',
 		'automatic_updates_complete',
 		'_core_updated_successfully',
 	];

--- a/surge.php
+++ b/surge.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/kovshenin/surge
  * Description: A fast and simple page caching plugin for WordPress
  * Author: Konstantin Kovshenin
- * Author URI: https://konstantil.blog
+ * Author URI: https://konstantin.blog
  * Text Domain: surge
  * Domain Path: /languages
  * Version: 1.0.0


### PR DESCRIPTION
In this PR:

* Flag requests with non-singular queries for a specific post_type
* Flag WooCommerce products to work around various caches
* Invalidate post_type caches on transition_post_status

This is work in progress, some of it related to #2.

Will also need to look at `nav_menu_items`, because those queries run with `suppress_filters` by-passing our `the_posts`. Also a very old but still in-use function `get_pages` does its own thing, but has some filters we can hook into.

cc @soulseekah