### PR TITLE
Feature: A way to modify the cache configuration

### DIFF
--- a/include/cache.php
+++ b/include/cache.php
@@ -20,6 +20,12 @@ include_once( __DIR__ . '/common.php' );
  * @return string Contents.
  */
 $ob_callback = function( $contents ) {
+	$ttl = config( 'ttl' );
+
+	if ( $ttl < 1 ) {
+		return $contents;
+	}
+
 	$skip = false;
 
 	foreach ( headers_list() as $header ) {
@@ -61,7 +67,7 @@ $ob_callback = function( $contents ) {
 		'code' => http_response_code(),
 		'headers' => $headers,
 		'created' => time(),
-		'expires' => time() + config( 'ttl' ),
+		'expires' => time() + $ttl,
 		'flags' => array_unique( flag() ),
 		'path' => $key['path'],
 	];

--- a/include/common.php
+++ b/include/common.php
@@ -19,7 +19,13 @@ const CACHE_DIR = WP_CONTENT_DIR . '/cache/surge';
  * @return mixed The config value for the supplied key.
  */
 function config( $key ) {
-	return [
+	static $config = null;
+
+	if ( isset( $config ) ) {
+		return $config[ $key ];
+	}
+
+	$config = [
 		'ttl' => 600,
 		'ignore_cookies' => [ 'wordpress_test_cookie' ],
 
@@ -39,7 +45,24 @@ function config( $key ) {
 			'hsa_src', 'hsa_ad', 'hsa_acc', 'hsa_net', 'hsa_kw', 'hsa_tgt',
 			'hsa_ver', '_branch_match_id',
 		],
-	][ $key ];
+
+		// Add items to this array to add a unique cache variant.
+		'variants' => [],
+	];
+
+	// Run a custom configuration file.
+	if ( defined( 'WP_CACHE_CONFIG' ) ) {
+		$_config = ( function( $config ) {
+			$_config = (array) include( WP_CACHE_CONFIG );
+			return $_config;
+		} ) ( $config );
+
+		foreach ( $_config as $_key => $_value ) {
+			$config[ $_key ] = $_value;
+		}
+	}
+
+	return $config[ $key ];
 }
 
 /**
@@ -74,6 +97,7 @@ function key() {
 		'path' => $path,
 		'query_vars' => $query_vars,
 		'cookies' => [],
+		'variants' => config( 'variants' ),
 	];
 
 	// Return early if this request is anonymized.

--- a/include/common.php
+++ b/include/common.php
@@ -57,9 +57,7 @@ function config( $key ) {
 			return $_config;
 		} ) ( $config );
 
-		foreach ( $_config as $_key => $_value ) {
-			$config[ $_key ] = $_value;
-		}
+		$config = array_merge( $config, $_config );
 	}
 
 	return $config[ $key ];


### PR DESCRIPTION
Following up on #1 here. Unfortunately the proposed solution in that PR doesn't quite work as part of the configuration code is executed way too early for any WordPress actions or filters to be called. In this PR users are allow dot create their own configuration file, and attach it with the `WP_CACHE_CONFIG` constant in wp-config.php, for example:

```
define( 'WP_CACHE', true );
define( 'WP_CACHE_CONFIG', __DIR__ . '/cache-config.php' );
```

The file itself has access to the original Surge `$config` but **must return** a valid configuration array. You can not unset any of the configuration keys, but you can extend them or override them. For example, if you wish to add your own ignored query variable, you would have the following config:

```
$config['ignore_query_vars'][] = 'custom_query_var';
return $config;
```

You can prevent the request from being cached by setting the TTL to zero, for example:

```
if ( false !== stripos( $_SERVER['HTTP_USER_AGENT'], 'googlebot' ) ) {
    $config['ttl'] = 0;
}

return $config;
```

If you wish to cache mobile visitors in a different cache bucket, you can use the `variants` array, like so:

```
function is_mobile() {
    // Your mobile check implementation
    return true; // or false
}

$config['variants']['mobile'] = is_mobile();
return $config;
```

Looking forward to your feedback @edwinsiebel!