### PR TITLE
Allow multiple headers with the same name.

### DIFF
--- a/include/cache.php
+++ b/include/cache.php
@@ -30,7 +30,7 @@ $ob_callback = function( $contents ) {
 
 	foreach ( headers_list() as $header ) {
 		list( $name, $value ) = array_map( 'trim', explode( ':', $header, 2 ) );
-		$headers[ $name ] = $value;
+		$headers[ $name ][] = $value;
 
 		if ( strtolower( $name ) == 'set-cookie' ) {
 			$skip = true;

--- a/include/serve.php
+++ b/include/serve.php
@@ -73,8 +73,10 @@ if ( $flags && ! empty( $meta['flags'] ) ) {
 // Set the HTTP response code and send headers.
 http_response_code( $meta['code'] );
 
-foreach ( $meta['headers'] as $name => $value ) {
-	header( "{$name}: {$value}" );
+foreach ( $meta['headers'] as $name => $values ) {
+	foreach( (array) $values as $value ){
+		header( "{$name}: {$value}", false );
+	}
 }
 
 header( 'X-Cache: hit' );


### PR DESCRIPTION
In HTTP headers it is allowed to specify the same name. In particular, it can be useful to specify links for preload:

```
Link: <https://example.com/other/styles.css>; rel=preload; as=style
Link: </theme/styles.css>; rel=preload; as=style
```

Some info about multiple headers https://stackoverflow.com/questions/3241326/set-more-than-one-http-header-with-the-same-name