### PR TITLE
Use `is_ssl`

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -120,7 +120,7 @@ function key() {
 	}
 
 	$cache_key = [
-		'https' => $_SERVER['HTTPS'] ?? '',
+		'https' => is_ssl(),
 		'method' => strtoupper( $_SERVER['REQUEST_METHOD'] ) ?? '',
 		'host' => strtolower( $_SERVER['HTTP_HOST'] ?? '' ),
 		'path' => $path,


### PR DESCRIPTION
Make use of the `is_ssl` WordPress method to match more use cases