### PR TITLE
Add an events API

### DIFF
--- a/include/cache.php
+++ b/include/cache.php
@@ -73,6 +73,7 @@ $ob_callback = function( $contents ) {
 	}
 
 	$key = key();
+	$has_cookies = ! empty( $key['cookies'] );
 
 	$meta = [
 		'code' => http_response_code(),
@@ -81,7 +82,7 @@ $ob_callback = function( $contents ) {
 		'expires' => time() + $ttl,
 		'flags' => array_unique( flag() ),
 		'path' => $key['path'],
-		'has_cookies' => ! empty( $key['cookies'] ),
+		'has_cookies' => $has_cookies,
 	];
 
 	$meta = json_encode( $meta );
@@ -119,12 +120,12 @@ $ob_callback = function( $contents ) {
 	$scope = 'public';
 
 	// Vary cache on cookie if we have any.
-	if ( $meta['has_cookies'] ) {
+	if ( $has_cookies ) {
 		header( 'Vary: Cookie' );
 		$scope = 'private';
 	}
 
-	header( sprintf( 'Cache-Control: %s, max-age=%d, stale-while-revalidate=%d',
+	header( sprintf( 'Cache-Control: %s, s-maxage=%d, stale-while-revalidate=%d',
 		$scope, $ttl, config( 'stale' ) ) );
 
 	return $contents;

--- a/include/cache.php
+++ b/include/cache.php
@@ -10,6 +10,10 @@
 
 namespace Surge;
 
+if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+	return;
+}
+
 include_once( __DIR__ . '/common.php' );
 
 /**
@@ -23,6 +27,7 @@ $ob_callback = function( $contents ) {
 	$ttl = config( 'ttl' );
 
 	if ( $ttl < 1 ) {
+		header( 'X-Cache: bypass' );
 		return $contents;
 	}
 
@@ -69,6 +74,7 @@ $ob_callback = function( $contents ) {
 	}
 
 	if ( $skip ) {
+		header( 'X-Cache: bypass' );
 		return $contents;
 	}
 
@@ -97,6 +103,7 @@ $ob_callback = function( $contents ) {
 
 	// Could not create file.
 	if ( false === $f ) {
+		header( 'X-Cache: bypass' );
 		return $contents;
 	}
 
@@ -115,7 +122,6 @@ $ob_callback = function( $contents ) {
 		unlink( CACHE_DIR . "/{$level}/{$cache_key}.{$hash}.php" );
 	}
 
-	header( 'X-Cache: miss' );
 	event( 'request', [ 'meta' => $meta ] );
 	return $contents;
 };

--- a/include/cache.php
+++ b/include/cache.php
@@ -81,6 +81,7 @@ $ob_callback = function( $contents ) {
 		'expires' => time() + $ttl,
 		'flags' => array_unique( flag() ),
 		'path' => $key['path'],
+		'has_cookies' => ! empty( $key['cookies'] ),
 	];
 
 	$meta = json_encode( $meta );
@@ -114,6 +115,17 @@ $ob_callback = function( $contents ) {
 	) {
 		unlink( CACHE_DIR . "/{$level}/{$cache_key}.{$hash}.php" );
 	}
+
+	$scope = 'public';
+
+	// Vary cache on cookie if we have any.
+	if ( $meta['has_cookies'] ) {
+		header( 'Vary: Cookie' );
+		$scope = 'private';
+	}
+
+	header( sprintf( 'Cache-Control: %s, s-maxage=%d, stale-while-revalidate=%d',
+		$scope, $ttl, config( 'stale' ) ) );
 
 	return $contents;
 };

--- a/include/cache.php
+++ b/include/cache.php
@@ -124,7 +124,7 @@ $ob_callback = function( $contents ) {
 		$scope = 'private';
 	}
 
-	header( sprintf( 'Cache-Control: %s, s-maxage=%d, stale-while-revalidate=%d',
+	header( sprintf( 'Cache-Control: %s, max-age=%d, stale-while-revalidate=%d',
 		$scope, $ttl, config( 'stale' ) ) );
 
 	return $contents;

--- a/include/common.php
+++ b/include/common.php
@@ -28,7 +28,6 @@ function config( $key ) {
 	$config = [
 		'ttl' => 600,
 		'ignore_cookies' => [ 'wordpress_test_cookie' ],
-		'stale' => 60,
 
 		// https://github.com/mpchadwick/tracking-query-params-registry/blob/master/_data/params.csv
 		'ignore_query_vars' => [
@@ -49,6 +48,9 @@ function config( $key ) {
 
 		// Add items to this array to add a unique cache variant.
 		'variants' => [],
+
+		// Add callbacks to events early to do crazy stuff.
+		'events' => [],
 	];
 
 	// Run a custom configuration file.
@@ -245,4 +247,22 @@ function anonymize( &$cache_key ) {
 
 	$cache_key['query_vars'] = [];
 	return true;
+}
+
+/**
+ * Execute an event.
+ *
+ * @param string $event The event name.
+ * @param array $args An array for arguments to pass to callbacks.
+ */
+function event( $event, $args ) {
+	$events = config( 'events' );
+
+	if ( empty( $events[ $event ] ) ) {
+		return;
+	}
+
+	foreach ( $events[ $event ] as $key => $callback ) {
+		$callback( $args );
+	}
 }

--- a/include/common.php
+++ b/include/common.php
@@ -28,6 +28,7 @@ function config( $key ) {
 	$config = [
 		'ttl' => 600,
 		'ignore_cookies' => [ 'wordpress_test_cookie' ],
+		'stale' => 60,
 
 		// https://github.com/mpchadwick/tracking-query-params-registry/blob/master/_data/params.csv
 		'ignore_query_vars' => [

--- a/include/invalidate.php
+++ b/include/invalidate.php
@@ -173,6 +173,8 @@ add_action( 'shutdown', function() {
 
 	fwrite( $f, '<?php exit; ?>' . json_encode( $flags ) );
 	fclose( $f );
+
+	event( 'expire', [ 'flags' => $expire ] );
 } );
 
 $expire_feeds = function() { expire( 'feed:' . get_current_blog_id() ); };

--- a/include/serve.php
+++ b/include/serve.php
@@ -88,7 +88,7 @@ if ( ! empty( $meta['has_cookies'] ) ) {
 	$scope = 'private';
 }
 
-header( sprintf( 'Cache-Control: %s, max-age=%d, stale-while-revalidate=%d',
+header( sprintf( 'Cache-Control: %s, s-maxage=%d, stale-while-revalidate=%d',
 	$scope, $meta['expires'] - time(), config( 'stale' ) ) );
 
 // header( 'X-Flags: ' . implode( ', ', $meta['flags'] ) );

--- a/include/serve.php
+++ b/include/serve.php
@@ -80,6 +80,17 @@ foreach ( $meta['headers'] as $name => $values ) {
 }
 
 header( 'X-Cache: hit' );
+
+$scope = 'public';
+// Vary cache on cookie if we have any.
+if ( ! empty( $meta['has_cookies'] ) ) {
+	header( 'Vary: Cookie' );
+	$scope = 'private';
+}
+
+header( sprintf( 'Cache-Control: %s, s-maxage=%d, stale-while-revalidate=%d',
+	$scope, $meta['expires'] - time(), config( 'stale' ) ) );
+
 // header( 'X-Flags: ' . implode( ', ', $meta['flags'] ) );
 fpassthru( $f ); // Pass the remaining bytes to the output.
 fclose( $f );

--- a/include/serve.php
+++ b/include/serve.php
@@ -16,7 +16,7 @@ if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 
 include_once( __DIR__ . '/common.php' );
 
-header( 'X-Cache: bypass' );
+header( 'X-Cache: miss' );
 $cache_key = md5( json_encode( key() ) );
 $level = substr( $cache_key, -2 );
 

--- a/include/serve.php
+++ b/include/serve.php
@@ -88,7 +88,7 @@ if ( ! empty( $meta['has_cookies'] ) ) {
 	$scope = 'private';
 }
 
-header( sprintf( 'Cache-Control: %s, s-maxage=%d, stale-while-revalidate=%d',
+header( sprintf( 'Cache-Control: %s, max-age=%d, stale-while-revalidate=%d',
 	$scope, $meta['expires'] - time(), config( 'stale' ) ) );
 
 // header( 'X-Flags: ' . implode( ', ', $meta['flags'] ) );

--- a/include/serve.php
+++ b/include/serve.php
@@ -16,7 +16,7 @@ if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
 
 include_once( __DIR__ . '/common.php' );
 
-header( 'X-Cache: miss' );
+header( 'X-Cache: bypass' );
 $cache_key = md5( json_encode( key() ) );
 $level = substr( $cache_key, -2 );
 
@@ -80,18 +80,7 @@ foreach ( $meta['headers'] as $name => $values ) {
 }
 
 header( 'X-Cache: hit' );
-
-$scope = 'public';
-// Vary cache on cookie if we have any.
-if ( ! empty( $meta['has_cookies'] ) ) {
-	header( 'Vary: Cookie' );
-	$scope = 'private';
-}
-
-header( sprintf( 'Cache-Control: %s, s-maxage=%d, stale-while-revalidate=%d',
-	$scope, $meta['expires'] - time(), config( 'stale' ) ) );
-
-// header( 'X-Flags: ' . implode( ', ', $meta['flags'] ) );
+event( 'request', [ 'meta' => $meta ] );
 fpassthru( $f ); // Pass the remaining bytes to the output.
 fclose( $f );
 die();


### PR DESCRIPTION
Two events are currently supported: `request` and `expire`, allows hooking into Surge to serve additional cache headers for example, this was implemented primarily for s-maxage support.