### PR TITLE
Add SURGE_ config constants: Bugfix

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -70,10 +70,10 @@ function config( $key ) {
 		$config = array_merge( $config, $_config );
 	}
 
-	foreach ( $config as $key => $value ) {
-		$const = 'SURGE_' . strtoupper( $key );
+	foreach ( $config as $config_key => $value ) {
+		$const = 'SURGE_' . strtoupper( $config_key );
 		if ( defined( $const ) ) {
-			$config[ $key ] = constant( $const );
+			$config[ $config_key ] = constant( $const );
 		}
 	}
 


### PR DESCRIPTION
The code added by https://github.com/kovshenin/surge/commit/8782e669df9eb9cfd9ce21ff678517b39373efc9 would overwrite the $key argument for the config() function.

Then config() calls would return different configuration variable than asked for when it's called the first time. It would work properly on the sub-sequent runs as it has a static $cache at the start where $key is not affected.